### PR TITLE
Update apt.dat EGTC Freq's

### DIFF
--- a/United Kingdom/EGTC/apt.dat
+++ b/United Kingdom/EGTC/apt.dat
@@ -611,7 +611,6 @@ I
 18  52.07253600 -000.61784400 1 BCN
 19  52.07766395 -000.61398210 1 WS
 19  52.06400986 -000.62131124 1 WS
-54 12285 Cranfield Approach
-54 13495 Cranfield Tower
+54 13493 Cranfield Tower
 50 12188 Cranfield Departure Information
 99


### PR DESCRIPTION
Cranfield approach does not exist anymore :( 
Cranfield tower on 134.930  and ATIS on 121.880
NATS AIP - http://www.ead.eurocontrol.int/eadbasic/pamslight-80100700C2592E43D4281826327425C0/7FE5QZZF3FXUS/EN/Charts/AD/NON_AIRAC/EG_AD_2_EGTC_2-1_en_2018-09-13.pdf